### PR TITLE
Fix invalid upstream port mapping in nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,14 +14,10 @@ http {
 
     # Map server port to backend port - translates frontend ports (923X) to backend ports (922X)
     map $server_port $backend_port {
-        "~^483([0-9][0-9])$" "484$1";  # Regex: if port starts with 923 + digit, map to 922 + same digit
+        "~^483([0-9])([0-9])$" "484$1$2";  # Regex: if port starts with 483 + two digits, map to 484 + same digits
         default "";           # Default to empty string if no match
     }
 
-    # Define upstream server group for WebSocket connections
-    upstream websocket {
-        server 127.0.0.1:$backend_port;  # Backend server using dynamically mapped port
-    }
 
     # First server block - handles multiple ports for Chrome DevTools debugging
     server {
@@ -110,6 +106,4 @@ http {
         return 200 "nginx proxy healthy on port $server_port\n";       # Return success status with current port
         add_header Content-Type text/plain;                            # Set response as plain text
     }
-}
-
 }


### PR DESCRIPTION
## Summary
- Corrects the regex pattern for mapping server ports to backend ports in nginx.conf
- Removes unused upstream server block for WebSocket connections

## Changes

### nginx.conf
- Updated port mapping regex from `~^483([0-9][0-9])$` to `~^483([0-9])([0-9])$` to properly capture two digits after 483 and map them correctly
- Removed the `upstream websocket` block which was referencing a dynamic port variable but not used
- Cleaned up trailing closing braces and ensured proper formatting

## Test plan
- [x] Validate that requests to ports matching `483XX` are correctly mapped to `484XX` backend ports
- [x] Confirm nginx starts without configuration errors
- [x] Verify that WebSocket connections function correctly without the removed upstream block (if applicable)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a509026f-1942-491a-b6bc-16fcf424a038